### PR TITLE
Get admin logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Authentication rules:
 - Every other `/api` route requires `Authorization: Bearer <token>`.
 - User-owned routes only allow the authenticated owner or an authenticated
   admin to access or mutate the resource.
+- Admin log routes require an authenticated admin user.
 
 ### Authentication
 | Method | Path | Notes |
@@ -118,6 +119,11 @@ Authentication rules:
 | GET | `/api/user_book_attributes/book_attribute_by_id/{attribute_id}` | Single attribute |
 | GET | `/api/user_book_attributes/book_attribute_by_user_id/` | Query: `user_id`, `limit`, `offset` |
 | GET | `/api/user_book_attributes/book_attribute_by_book_id/` | Query: `book_id` |
+
+### Admin Logs (DB)
+| Method | Path | Notes |
+|---|---|---|
+| POST | `/api/database/get_admin_logs/` | Admin-only. Body: `GetAdminLogsRequest`; returns paginated `GetAdminLogsResponse` |
 
 ## Development Commands
 Run these from the project root.

--- a/app/api/admin_logs/get_admin_logs.py
+++ b/app/api/admin_logs/get_admin_logs.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from app.crud.admin_logs_crud import (
+    convert_admin_logs,
+    get_admin_logs,
+)
+from app.db.db_conn import db_manager
+from app.db.db_models.user import User
+from app.models.admin_log import GetAdminLogsRequest, GetAdminLogsResponse
+from app.utils.api_token import get_current_user
+from app.utils.authorization import ensure_current_user_is_admin
+
+router = APIRouter(prefix="/database", tags=["admin-logs"])
+
+
+@router.post(
+    "/get_admin_logs/",
+    response_model=GetAdminLogsResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def admin_logs_get(
+    admin_logs_request: GetAdminLogsRequest,
+    session: Session = Depends(db_manager.get_db),
+    current_user: User = Depends(get_current_user),
+) -> GetAdminLogsResponse:
+    ensure_current_user_is_admin(
+        current_user,
+        resource_name="get_admin_logs",
+    )
+    admin_logs, total = get_admin_logs(
+        admin_logs_request.start_time,
+        admin_logs_request.end_time,
+        admin_logs_request.limit,
+        admin_logs_request.offset,
+        session,
+    )
+    log_models = [convert_admin_logs(admin_log) for admin_log in admin_logs]
+    return GetAdminLogsResponse(
+        logs=log_models,
+        limit=admin_logs_request.limit,
+        offset=admin_logs_request.offset,
+        count=len(log_models),
+        total=total,
+    )

--- a/app/api/admin_logs/router.py
+++ b/app/api/admin_logs/router.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+from app.api.admin_logs.get_admin_logs import router as get_admin_logs
+
+router = APIRouter()
+
+router.include_router(get_admin_logs)

--- a/app/crud/admin_logs_crud.py
+++ b/app/crud/admin_logs_crud.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.db.db_conn import db_manager
@@ -15,6 +18,31 @@ def create_admin_logs(admin_log_model: AdminLogsModel, session: Session) -> Admi
 
 def get_admin_logs_by_id(admin_log_id: int, session: Session) -> AdminLogs | None:
     return session.get(AdminLogs, admin_log_id)
+
+
+def get_admin_logs(
+    start_time: datetime,
+    end_time: datetime,
+    limit: int,
+    offset: int,
+    session: Session,
+) -> tuple[list[AdminLogs], int]:
+    filters = (
+        AdminLogs.created_at >= start_time,
+        AdminLogs.created_at <= end_time,
+    )
+    logs_stmt = (
+        select(AdminLogs)
+        .where(*filters)
+        .order_by(AdminLogs.created_at.desc(), AdminLogs.id.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    total_stmt = select(func.count()).select_from(AdminLogs).where(*filters)
+
+    admin_logs = list(session.scalars(logs_stmt).all())
+    total = session.scalar(total_stmt)
+    return admin_logs, total or 0
 
 
 def update_admin_logs(
@@ -47,5 +75,5 @@ def delete_admin_logs(admin_log_id: int, session: Session) -> bool:
     return True
 
 
-def convert_admin_logs(admin_logs_model: AdminLogsModel) -> AdminLogsModel:
+def convert_admin_logs(admin_logs_model: AdminLogs) -> AdminLogsModel:
     return AdminLogsModel.model_validate(admin_logs_model)

--- a/app/crud/crud_tests/test_admin_logs_crud.py
+++ b/app/crud/crud_tests/test_admin_logs_crud.py
@@ -1,0 +1,80 @@
+import os
+from collections.abc import Generator
+from datetime import datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+os.environ.setdefault("DATABASE_USERNAME", "test")
+os.environ.setdefault("DATABASE_PASSWORD", "test")
+os.environ.setdefault("DATABASE_URL", "localhost")
+os.environ.setdefault("DATABASE_NAME", "test")
+os.environ.setdefault("GOOGLE_BOOKS_API_URL", "https://example.com/books")
+os.environ.setdefault("GOOGLE_BOOKS_API_KEY", "test-key")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
+from app.crud.admin_logs_crud import get_admin_logs
+from app.db.db_models.admin_logs import AdminLogs
+
+
+@pytest.fixture
+def session() -> Generator[Session, None, None]:
+    engine = create_engine("sqlite:///:memory:")
+    AdminLogs.__table__.create(bind=engine)
+    with Session(engine) as test_session:
+        yield test_session
+
+
+def test_get_admin_logs_filters_orders_paginates_and_counts(
+    session: Session,
+) -> None:
+    start_time = datetime(2026, 4, 1, 0, 0, 0)
+    middle_time = datetime(2026, 4, 15, 12, 0, 0)
+    end_time = datetime(2026, 4, 30, 23, 59, 59)
+    session.add_all(
+        [
+            AdminLogs(
+                id=1,
+                event_type="create",
+                event_description="Outside range",
+                created_at=datetime(2026, 3, 31, 23, 59, 59),
+            ),
+            AdminLogs(
+                id=2,
+                event_type="create",
+                event_description="Start boundary",
+                created_at=start_time,
+            ),
+            AdminLogs(
+                id=3,
+                event_type="update",
+                event_description="Middle lower id",
+                created_at=middle_time,
+            ),
+            AdminLogs(
+                id=4,
+                event_type="delete",
+                event_description="Middle higher id",
+                created_at=middle_time,
+            ),
+            AdminLogs(
+                id=5,
+                event_type="modify",
+                event_description="End boundary",
+                created_at=end_time,
+            ),
+        ]
+    )
+    session.commit()
+
+    admin_logs, total = get_admin_logs(
+        start_time,
+        end_time,
+        2,
+        1,
+        session,
+    )
+
+    assert total == 4
+    assert [admin_log.id for admin_log in admin_logs] == [4, 3]

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from app.api.admin_logs.router import router as admin_logs_route
 from app.api.bookcase.router import router as bookcase_route
 from app.api.books.router import router as book_route
 from app.api.user_book_attributes.router import router as user_book_attributes
@@ -22,6 +23,7 @@ app.include_router(book_route, prefix=prefix)
 app.include_router(user_book_attributes, prefix=prefix)
 app.include_router(bookcase_route, prefix=prefix)
 app.include_router(user_router, prefix=prefix)
+app.include_router(admin_logs_route, prefix=prefix)
 
 
 def get_database_error_details(exc: DatabaseOperationError) -> tuple[str, str]:

--- a/app/models/admin_log.py
+++ b/app/models/admin_log.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AdminEventType(str, Enum):
@@ -25,7 +25,50 @@ class AdminLogsModel(BaseModel):
         description="Admin event description", examples=["Modified user status"]
     )
     created_at: datetime = Field(
-        datetime.now(),
+        default_factory=datetime.now,
         description="Admin event created time",
-        examples=[datetime.now()],
+        examples=[datetime(2026, 4, 30, 12, 0, 0)],
+    )
+
+
+class GetAdminLogsRequest(BaseModel):
+    start_time: datetime = Field(
+        description="Inclusive start time for admin log filtering.",
+        examples=[datetime(2026, 4, 1, 0, 0, 0)],
+    )
+    end_time: datetime = Field(
+        description="Inclusive end time for admin log filtering.",
+        examples=[datetime(2026, 4, 30, 23, 59, 59)],
+    )
+    limit: int = Field(
+        default=100,
+        description="Maximum number of admin logs to return.",
+        examples=[100],
+        ge=1,
+    )
+    offset: int = Field(
+        default=0,
+        description="Number of matching admin logs to skip.",
+        examples=[0],
+        ge=0,
+    )
+
+    @model_validator(mode="after")
+    def validate_time_frame(self) -> "GetAdminLogsRequest":
+        if self.end_time < self.start_time:
+            raise ValueError("end_time must be greater than or equal to start_time.")
+        return self
+
+
+class GetAdminLogsResponse(BaseModel):
+    logs: list[AdminLogsModel] = Field(
+        description="The admin logs for the requested page."
+    )
+    limit: int = Field(description="Requested page size.", examples=[100], ge=1)
+    offset: int = Field(description="Requested page offset.", examples=[0], ge=0)
+    count: int = Field(description="Number of logs returned.", examples=[25], ge=0)
+    total: int = Field(
+        description="Total number of logs matching the time frame.",
+        examples=[125],
+        ge=0,
     )

--- a/app/tests/test_admin_logs_api.py
+++ b/app/tests/test_admin_logs_api.py
@@ -1,0 +1,210 @@
+import os
+from datetime import datetime
+from typing import Generator
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("DATABASE_USERNAME", "test")
+os.environ.setdefault("DATABASE_PASSWORD", "test")
+os.environ.setdefault("DATABASE_URL", "localhost")
+os.environ.setdefault("DATABASE_NAME", "test")
+os.environ.setdefault("GOOGLE_BOOKS_API_URL", "https://example.com/books")
+os.environ.setdefault("GOOGLE_BOOKS_API_KEY", "test-key")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
+from app.api.admin_logs import get_admin_logs as admin_logs_routes
+from app.db.db_conn import db_manager
+from app.db.db_models.admin_logs import AdminLogs
+from app.db.db_models.user import User
+from app.main import app
+from app.utils import api_token as api_token_module
+from app.utils.api_token import create_access_token
+
+
+START_TIME = datetime(2026, 4, 1, 0, 0, 0)
+END_TIME = datetime(2026, 4, 30, 23, 59, 59)
+
+
+def make_user(
+    user_id: int = 1,
+    username: str = "admin_user",
+    email: str = "admin@example.com",
+    role: str = "admin",
+) -> User:
+    return User(
+        id=user_id,
+        first_name="Test",
+        last_name="User",
+        username=username,
+        email=email,
+        password_hash="hashed-password",
+        role=role,
+        created_at=datetime.now(),
+        last_login=None,
+    )
+
+
+@pytest.fixture
+def session() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def client(session: MagicMock) -> Generator[TestClient, None, None]:
+    def override_get_db() -> Generator[MagicMock, None, None]:
+        yield session
+
+    app.dependency_overrides[db_manager.get_db] = override_get_db
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+def auth_header(user_id: int) -> dict[str, str]:
+    token = create_access_token(subject=user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def admin_logs_payload() -> dict[str, str | int]:
+    return {
+        "start_time": START_TIME.isoformat(),
+        "end_time": END_TIME.isoformat(),
+        "limit": 2,
+        "offset": 1,
+    }
+
+
+def test_get_admin_logs_returns_paginated_logs_for_admin(
+    client: TestClient, session: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    admin_user = make_user()
+    monkeypatch.setattr(
+        api_token_module,
+        "get_user_by_id",
+        lambda user_id, session: admin_user if user_id == 1 else None,
+    )
+
+    def fake_get_admin_logs(
+        start_time: datetime,
+        end_time: datetime,
+        limit: int,
+        offset: int,
+        session: MagicMock,
+    ) -> tuple[list[AdminLogs], int]:
+        assert start_time == START_TIME
+        assert end_time == END_TIME
+        assert limit == 2
+        assert offset == 1
+        return (
+            [
+                AdminLogs(
+                    id=4,
+                    event_type="delete",
+                    event_description="Deleted user",
+                    created_at=datetime(2026, 4, 25, 10, 0, 0),
+                ),
+                AdminLogs(
+                    id=3,
+                    event_type="create",
+                    event_description="Created book",
+                    created_at=datetime(2026, 4, 20, 10, 0, 0),
+                ),
+            ],
+            7,
+        )
+
+    monkeypatch.setattr(admin_logs_routes, "get_admin_logs", fake_get_admin_logs)
+
+    response = client.post(
+        "/api/database/get_admin_logs/",
+        headers=auth_header(1),
+        json=admin_logs_payload(),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "logs": [
+            {
+                "id": 4,
+                "event_type": "delete",
+                "event_description": "Deleted user",
+                "created_at": "2026-04-25T10:00:00",
+            },
+            {
+                "id": 3,
+                "event_type": "create",
+                "event_description": "Created book",
+                "created_at": "2026-04-20T10:00:00",
+            },
+        ],
+        "limit": 2,
+        "offset": 1,
+        "count": 2,
+        "total": 7,
+    }
+
+
+def test_get_admin_logs_rejects_non_admin_user(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current_user = make_user(
+        username="regular_user",
+        email="regular@example.com",
+        role="user",
+    )
+    get_admin_logs_mock = MagicMock()
+    monkeypatch.setattr(
+        api_token_module,
+        "get_user_by_id",
+        lambda user_id, session: current_user if user_id == 1 else None,
+    )
+    monkeypatch.setattr(admin_logs_routes, "get_admin_logs", get_admin_logs_mock)
+
+    response = client.post(
+        "/api/database/get_admin_logs/",
+        headers=auth_header(1),
+        json=admin_logs_payload(),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "You do not have access to this resource."
+    get_admin_logs_mock.assert_not_called()
+
+
+def test_get_admin_logs_requires_authentication(client: TestClient) -> None:
+    response = client.post(
+        "/api/database/get_admin_logs/",
+        json=admin_logs_payload(),
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+
+
+def test_get_admin_logs_rejects_invalid_time_frame(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    admin_user = make_user()
+    get_admin_logs_mock = MagicMock()
+    monkeypatch.setattr(
+        api_token_module,
+        "get_user_by_id",
+        lambda user_id, session: admin_user if user_id == 1 else None,
+    )
+    monkeypatch.setattr(admin_logs_routes, "get_admin_logs", get_admin_logs_mock)
+
+    response = client.post(
+        "/api/database/get_admin_logs/",
+        headers=auth_header(1),
+        json={
+            "start_time": END_TIME.isoformat(),
+            "end_time": START_TIME.isoformat(),
+            "limit": 2,
+            "offset": 0,
+        },
+    )
+
+    assert response.status_code == 422
+    get_admin_logs_mock.assert_not_called()

--- a/app/tests/test_auth_api.py
+++ b/app/tests/test_auth_api.py
@@ -27,7 +27,6 @@ from app.utils.api_token import create_access_token
 
 
 def make_user(
-    *,
     user_id: int = 1,
     username: str = "owner",
     email: str = "owner@example.com",

--- a/app/utils/authorization.py
+++ b/app/utils/authorization.py
@@ -8,18 +8,29 @@ logger = get_logger(__name__)
 FORBIDDEN_DETAIL = "You do not have access to this resource."
 
 
-def _is_admin(current_user: User) -> bool:
-    return current_user.role == "admin"
+def ensure_current_user_is_admin(
+    current_user: User,
+    resource_name: str,
+) -> None:
+    if current_user.role == "admin":
+        return
+
+    logger.error(
+        f"Authorization denied for {resource_name}. current_user_id={current_user.id}",
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=FORBIDDEN_DETAIL,
+    )
 
 
 def ensure_current_user_matches_user_id(
     current_user: User,
     target_user_id: int,
-    *,
     resource_name: str,
     resource_id: int | None = None,
 ) -> None:
-    if _is_admin(current_user) or current_user.id == target_user_id:
+    if current_user.role == "admin" or current_user.id == target_user_id:
         return
 
     logger.error(
@@ -35,10 +46,9 @@ def ensure_current_user_matches_user_id(
 def ensure_current_user_matches_username(
     current_user: User,
     target_username: str,
-    *,
     resource_name: str,
 ) -> None:
-    if _is_admin(current_user) or current_user.username == target_username:
+    if current_user.role == "admin" or current_user.username == target_username:
         return
 
     logger.error(
@@ -54,10 +64,9 @@ def ensure_current_user_matches_username(
 def ensure_current_user_matches_email(
     current_user: User,
     target_email: str,
-    *,
     resource_name: str,
 ) -> None:
-    if _is_admin(current_user) or current_user.email == target_email:
+    if current_user.role == "admin" or current_user.email == target_email:
         return
 
     logger.error(


### PR DESCRIPTION
## Summary

Adds an admin-only endpoint for retrieving admin logs from the `admin_logs` table with required time-frame filtering and pagination.

## Changes

- Added `POST /api/database/get_admin_logs/`
- Added `GetAdminLogsRequest` and `GetAdminLogsResponse` Pydantic models
- Added paginated `get_admin_logs` CRUD function with:
  - `created_at` start/end filtering
  - newest-first ordering
  - `limit` / `offset` pagination
  - total matching row count
- Added admin-only authorization helper using `current_user.role == "admin"`
- Registered a new `admin_logs` API router
- Added route documentation to `README.md`
- Added API and CRUD tests for admin-log retrieval

## Testing

- `uv run pytest -q app/tests/test_admin_logs_api.py app/crud/crud_tests/test_admin_logs_crud.py`
- `uv run pytest -q app/tests/test_auth_api.py`
- `.venv/bin/ruff check ...`
- `.venv/bin/ty check ...`

## Notes

- No database schema changes were made.
- No Alembic migration was added.
- `proj_requirements/tasks/get_admin_logs.md` was not modified.

closes #34
